### PR TITLE
fix: dataset title to use all available space

### DIFF
--- a/src/scss/dataset-tabs-cross-dataset-mode.scss
+++ b/src/scss/dataset-tabs-cross-dataset-mode.scss
@@ -14,7 +14,7 @@
   }
 
   &-item {
-    @apply bg-transparent border-0 p-0 text-left text-neutrals-800 font-semibold text-[14px] leading-[16px] truncate min-w-0 max-w-[220px];
+    @apply bg-transparent border-0 p-0 text-left text-neutrals-800 font-semibold text-[14px] leading-[16px] truncate min-w-0;
   }
 
   &-separator {


### PR DESCRIPTION
### Applicable issues
[Not all chat area width is used to display datasets titles](https://github.com/epam/statgpt-global-trusted-data-commons/issues/153)

### Description of changes

Fix dataset tabs styles

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
