### PR TITLE
fix: API endpoints returning text/html MIME type instead of application/json 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,6 @@
         "@epam/statgpt-sdmx-toolkit": "0.4.0",
         "@epam/statgpt-shared-toolkit": "0.4.0",
         "@epam/statgpt-ui-components": "0.4.0",
-        "@epam/statgpt-conversation-list": "0.4.0",
-        "@epam/statgpt-conversation-view": "0.4.0",
-        "@epam/statgpt-dial-toolkit": "0.4.0",
-        "@epam/statgpt-sdmx-toolkit": "0.4.0",
-        "@epam/statgpt-shared-toolkit": "0.4.0",
-        "@epam/statgpt-ui-components": "0.4.0",
         "@floating-ui/react": "^0.27.16",
         "@monaco-editor/react": "^4.7.0",
         "@tabler/icons-react": "^3.34.0",
@@ -1912,9 +1906,10 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1924,6 +1919,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
       "optional": true
     },
     "node_modules/@epam/ai-dial-chat-visualizer-connector": {
@@ -1961,15 +1957,9 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@epam/statgpt-conversation-list/-/statgpt-conversation-list-0.4.0.tgz",
       "integrity": "sha512-NUh+34ZDDag78lcYOymafJmkW1qtHl5JCoCPyp09kIrh3jB9aSuyn+olMVq+QmM/LUxDZVlKBtwyGnpjPDORvw==",
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@epam/statgpt-conversation-list/-/statgpt-conversation-list-0.4.0.tgz",
-      "integrity": "sha512-NUh+34ZDDag78lcYOymafJmkW1qtHl5JCoCPyp09kIrh3jB9aSuyn+olMVq+QmM/LUxDZVlKBtwyGnpjPDORvw==",
       "license": "MIT",
       "dependencies": {
         "@epam/ai-dial-shared": "^0.43.3",
-        "@epam/statgpt-dial-toolkit": "0.4.0",
-        "@epam/statgpt-shared-toolkit": "0.4.0",
-        "@epam/statgpt-ui-components": "0.4.0",
         "@epam/statgpt-dial-toolkit": "0.4.0",
         "@epam/statgpt-shared-toolkit": "0.4.0",
         "@epam/statgpt-ui-components": "0.4.0",
@@ -1986,17 +1976,9 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@epam/statgpt-conversation-view/-/statgpt-conversation-view-0.4.0.tgz",
       "integrity": "sha512-z18WmIUxederEEExwRNqWqHFKknQDA7eE9peU5hjPXUQDMl+IQ4nrJzCmaGFc/iXJOi3tZMj1kA65Mguuv6IzQ==",
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@epam/statgpt-conversation-view/-/statgpt-conversation-view-0.4.0.tgz",
-      "integrity": "sha512-z18WmIUxederEEExwRNqWqHFKknQDA7eE9peU5hjPXUQDMl+IQ4nrJzCmaGFc/iXJOi3tZMj1kA65Mguuv6IzQ==",
       "license": "MIT",
       "dependencies": {
         "@epam/ai-dial-shared": "^0.43.3",
-        "@epam/statgpt-conversation-list": "0.4.0",
-        "@epam/statgpt-dial-toolkit": "0.4.0",
-        "@epam/statgpt-sdmx-toolkit": "0.4.0",
-        "@epam/statgpt-shared-toolkit": "0.4.0",
-        "@epam/statgpt-ui-components": "0.4.0",
         "@epam/statgpt-conversation-list": "0.4.0",
         "@epam/statgpt-dial-toolkit": "0.4.0",
         "@epam/statgpt-sdmx-toolkit": "0.4.0",
@@ -2029,13 +2011,9 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@epam/statgpt-dial-toolkit/-/statgpt-dial-toolkit-0.4.0.tgz",
       "integrity": "sha512-Bqa6zKTkpYK4IzKoqKVEF2bLCv/DE/xdbhNkMjrJKJBBPf8+V13/MUf2Bh/d4SDg/D5pFbgxZp0/c7tdyTa0iQ==",
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@epam/statgpt-dial-toolkit/-/statgpt-dial-toolkit-0.4.0.tgz",
-      "integrity": "sha512-Bqa6zKTkpYK4IzKoqKVEF2bLCv/DE/xdbhNkMjrJKJBBPf8+V13/MUf2Bh/d4SDg/D5pFbgxZp0/c7tdyTa0iQ==",
       "license": "MIT",
       "dependencies": {
         "@epam/ai-dial-shared": "^0.43.3",
-        "@epam/statgpt-shared-toolkit": "0.4.0"
         "@epam/statgpt-shared-toolkit": "0.4.0"
       }
     },
@@ -2043,13 +2021,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@epam/statgpt-sdmx-toolkit/-/statgpt-sdmx-toolkit-0.4.0.tgz",
       "integrity": "sha512-2BjbNso4cc6X7oZMPMbMXdFl8Hd/Xz9cAp6R/2FzqBTgzALYDvWo2l2ehSjt5YRK7vL+7+c3kPoSQXnPCbK6AA==",
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@epam/statgpt-sdmx-toolkit/-/statgpt-sdmx-toolkit-0.4.0.tgz",
-      "integrity": "sha512-2BjbNso4cc6X7oZMPMbMXdFl8Hd/Xz9cAp6R/2FzqBTgzALYDvWo2l2ehSjt5YRK7vL+7+c3kPoSQXnPCbK6AA==",
       "license": "MIT",
       "dependencies": {
-        "@epam/statgpt-dial-toolkit": "0.4.0",
-        "@epam/statgpt-shared-toolkit": "0.4.0",
         "@epam/statgpt-dial-toolkit": "0.4.0",
         "@epam/statgpt-shared-toolkit": "0.4.0",
         "compare-versions": "^6.1.1",
@@ -2057,9 +2030,6 @@
       }
     },
     "node_modules/@epam/statgpt-shared-toolkit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@epam/statgpt-shared-toolkit/-/statgpt-shared-toolkit-0.4.0.tgz",
-      "integrity": "sha512-kzQQRzZOxRzN30pNytqOWovnRjKAmZMb9+xjutm0OZBboPhnmu3eWggMUmpqFv4lgDDSXu8DpFDO7ZEY/KI0bw==",
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@epam/statgpt-shared-toolkit/-/statgpt-shared-toolkit-0.4.0.tgz",
       "integrity": "sha512-kzQQRzZOxRzN30pNytqOWovnRjKAmZMb9+xjutm0OZBboPhnmu3eWggMUmpqFv4lgDDSXu8DpFDO7ZEY/KI0bw==",
@@ -2073,15 +2043,11 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@epam/statgpt-ui-components/-/statgpt-ui-components-0.4.0.tgz",
       "integrity": "sha512-zkCs3vbFuo8yg8ONVA7Vazz0Q3Qf6ZIuE/IvFw+vqYp51esIuRKE4dz1qZc420SBSIHaU9V4ni2zOygk5xMwsw==",
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@epam/statgpt-ui-components/-/statgpt-ui-components-0.4.0.tgz",
-      "integrity": "sha512-zkCs3vbFuo8yg8ONVA7Vazz0Q3Qf6ZIuE/IvFw+vqYp51esIuRKE4dz1qZc420SBSIHaU9V4ni2zOygk5xMwsw==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@epam/statgpt-shared-toolkit": "0.4.0",
         "@epam/statgpt-shared-toolkit": "0.4.0",
         "@floating-ui/react": "^0.27.14",
         "@tabler/icons-react": "^3.34.1",
@@ -2101,6 +2067,7 @@
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -2117,6 +2084,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -2133,6 +2101,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -2149,6 +2118,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -2181,6 +2151,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2197,6 +2168,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -2213,6 +2185,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -2229,6 +2202,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2245,6 +2219,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2261,6 +2236,7 @@
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2277,6 +2253,7 @@
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2293,6 +2270,7 @@
         "mips64el"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2309,6 +2287,7 @@
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2325,6 +2304,7 @@
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2341,6 +2321,7 @@
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2357,6 +2338,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2373,6 +2355,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -2389,6 +2372,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -2405,6 +2389,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -2421,6 +2406,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -2437,6 +2423,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
@@ -2453,6 +2440,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -2469,6 +2457,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2485,6 +2474,7 @@
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2501,6 +2491,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2776,6 +2767,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -2812,6 +2804,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "darwin"
@@ -2827,6 +2820,10 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -2842,6 +2839,10 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -2857,6 +2858,10 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -2872,6 +2877,10 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -2887,6 +2896,10 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -2902,6 +2915,10 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -2917,6 +2934,10 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -2932,6 +2953,10 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -2947,6 +2972,10 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -2968,6 +2997,10 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -2989,6 +3022,10 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3010,6 +3047,10 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3031,6 +3072,10 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3052,6 +3097,10 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3073,6 +3122,10 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3094,6 +3147,10 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3115,6 +3172,7 @@
       "cpu": [
         "wasm32"
       ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
@@ -3133,6 +3191,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
@@ -3151,6 +3210,7 @@
       "cpu": [
         "ia32"
       ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
@@ -3169,6 +3229,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
@@ -3301,6 +3362,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3316,6 +3380,9 @@
       "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3333,6 +3400,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3348,6 +3418,9 @@
       "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3475,6 +3548,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -3513,6 +3587,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -3532,6 +3607,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -3551,6 +3627,10 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3570,6 +3650,10 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3589,6 +3673,10 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3608,6 +3696,10 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3627,6 +3719,10 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3646,6 +3742,10 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3665,6 +3765,7 @@
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -3684,6 +3785,7 @@
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -3703,6 +3805,7 @@
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -3761,6 +3864,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -3774,6 +3878,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -3800,6 +3905,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -3813,6 +3919,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -3826,6 +3933,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -3839,6 +3947,10 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3852,6 +3964,10 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3865,6 +3981,10 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3878,6 +3998,10 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3891,6 +4015,10 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3904,6 +4032,10 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3917,6 +4049,10 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3930,6 +4066,10 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3943,6 +4083,10 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3956,6 +4100,10 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3969,6 +4117,10 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3982,6 +4134,10 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -3995,6 +4151,10 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4008,6 +4168,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -4021,6 +4182,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
@@ -4034,6 +4196,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4047,6 +4210,7 @@
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4060,6 +4224,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4073,6 +4238,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"

--- a/src/app/api/[[...path]]/route.ts
+++ b/src/app/api/[[...path]]/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+
+const notFoundResponse = () =>
+  NextResponse.json({ error: 'Not Found' }, { status: 404 });
+
+export function GET() {
+  return notFoundResponse();
+}
+
+export function POST() {
+  return notFoundResponse();
+}
+
+export function PUT() {
+  return notFoundResponse();
+}
+
+export function DELETE() {
+  return notFoundResponse();
+}
+
+export function PATCH() {
+  return notFoundResponse();
+}
+
+export function OPTIONS() {
+  return notFoundResponse();
+}

--- a/src/app/api/download/route.ts
+++ b/src/app/api/download/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { datasetApi } from '../api';
 import {
   FileColumnsAttribute,
@@ -6,27 +6,36 @@ import {
 } from '@epam/statgpt-sdmx-toolkit';
 import { withAuth } from '../../../utils/auth/withAuth';
 import { AuthParams } from '../../../models/auth';
+import { apiLogger } from '../../../core/logger';
 
 export const GET = withAuth(
   async (request: NextRequest, { token }: AuthParams) => {
-    const { searchParams } = new URL(request.url);
-    const urn = searchParams.get('urn') as string;
-    const format = searchParams.get('format') as SdmxDataFormat;
-    const language = searchParams.get('language') as string;
-    const attribute = searchParams.get('attribute') as FileColumnsAttribute;
-    const filename = searchParams.get('filename') as string;
-    const filters = JSON.parse(searchParams.get('filters') || '{}');
-    const isMetadata = searchParams.get('isMetadata') === 'true';
+    try {
+      const { searchParams } = new URL(request.url);
+      const urn = searchParams.get('urn') as string;
+      const format = searchParams.get('format') as SdmxDataFormat;
+      const language = searchParams.get('language') as string;
+      const attribute = searchParams.get('attribute') as FileColumnsAttribute;
+      const filename = searchParams.get('filename') as string;
+      const filters = JSON.parse(searchParams.get('filters') || '{}');
+      const isMetadata = searchParams.get('isMetadata') === 'true';
 
-    return datasetApi.downloadDataSet(
-      urn,
-      format,
-      language,
-      attribute,
-      filters,
-      filename,
-      isMetadata,
-      token?.access_token as string,
-    );
+      return datasetApi.downloadDataSet(
+        urn,
+        format,
+        language,
+        attribute,
+        filters,
+        filename,
+        isMetadata,
+        token?.access_token as string,
+      );
+    } catch (error) {
+      apiLogger.error('Download API error:', error);
+      return NextResponse.json(
+        { error: 'Failed to process download request' },
+        { status: 500 },
+      );
+    }
   },
 );

--- a/src/utils/auth/withAuth.ts
+++ b/src/utils/auth/withAuth.ts
@@ -14,20 +14,20 @@ export function withAuth<TContext>(
   ) => Promise<NextResponse | Response>,
 ) {
   return async (req: NextRequest, context: TContext) => {
-    const token = await getToken({ req });
-    const isEnableAuth = getIsEnableAuthToggle();
-    const isInvalidSession = await getIsInvalidSession(isEnableAuth, token);
-
-    if (isInvalidSession) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: HTTP_ERROR_CODES.UNAUTHORIZED },
-      );
-    }
-
-    const authParams = { token: token ?? {} };
-
     try {
+      const token = await getToken({ req });
+      const isEnableAuth = getIsEnableAuthToggle();
+      const isInvalidSession = await getIsInvalidSession(isEnableAuth, token);
+
+      if (isInvalidSession) {
+        return NextResponse.json(
+          { error: 'Unauthorized' },
+          { status: HTTP_ERROR_CODES.UNAUTHORIZED },
+        );
+      }
+
+      const authParams = { token: token ?? {} };
+
       return await handler(req, authParams, context);
     } catch (error) {
       apiLogger.error('Error in withAuth middleware: ${}', { error });


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
#202

### Description of changes

Backend API endpoints were returning Content-Type: text/html; charset=utf-8 in error scenarios and for unknown paths, due to unhandled exceptions falling through to Next.js's default HTML error pages. 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
