### PR TITLE
fix: use federated logout on NoAccessView sign out button

### DIFF
--- a/src/components/NoAccessView.tsx
+++ b/src/components/NoAccessView.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Button } from '@epam/statgpt-ui-components';
-import { signOut } from 'next-auth/react';
 import { TranslateI18nFn, useI18n } from '../locales/client';
 import {
   AuthI18nKeys,
@@ -9,6 +8,7 @@ import {
   StatusMessagesI18nKeys,
 } from '../constants/i18n-keys';
 import LogoIcon from '../../public/images/logo.svg';
+import { useLogout } from '../hooks/use-logout';
 
 export const NoAccessView = ({
   clientContactSupportUrl,
@@ -16,6 +16,7 @@ export const NoAccessView = ({
   clientContactSupportUrl?: string;
 }) => {
   const t = useI18n() as TranslateI18nFn;
+  const { handleLogout } = useLogout();
 
   return (
     <div className="flex size-full">
@@ -56,7 +57,7 @@ export const NoAccessView = ({
           <Button
             buttonClassName="text-button-secondary w-fit !py-[14px] !px-[45px]"
             title={t(AuthI18nKeys.SIGN_OUT)}
-            onClick={() => signOut()}
+            onClick={handleLogout}
           />
         </div>
       </div>


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #213 

### Description of changes

The Sign Out button on the No Access page was calling signOut() from next-auth/react directly, which only clears the local session without triggering the identity provider's federated logout flow. This replaces the inline signOut() call with useLogout hook (already used elsewhere in the app), so users are fully signed out from the IdP when leaving the No Access page — consistent with logout behavior across the rest of the application.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
