### PR TITLE
chore: migrate deprecated Sass @import to @use

### DIFF
--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -21,9 +21,9 @@
 @use 'alert.scss';
 @use 'chart-attachment.scss';
 @use 'colors.scss';
+@use '@epam/statgpt-ui-components/styles-tailwind.scss';
 
 @import 'flatpickr/dist/themes/light.css';
-@import '@epam/statgpt-ui-components/styles-tailwind.scss';
 
 body {
   font-family: var(--font-open-sans);


### PR DESCRIPTION
### Applicable issues

### Description of changes

Replaces the deprecated Sass `@import` syntax with `@use` in the app's stylesheets to silence the Dart Sass deprecation warnings.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
