### PR TITLE
fix: pin ORT version to 85.0.0 to unblock CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,3 +18,4 @@ jobs:
     secrets: inherit
     with:
       node-version: "24"
+      ort-version: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,4 +18,4 @@ jobs:
     secrets: inherit
     with:
       node-version: "24"
-      ort-version: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+      ort-version: "87.3.0" # pin ORT: "latest" is unstable; >=87.2.0 required by current ort-config@main rules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       code-checks-bypassed: false
       ort-enabled: true
       ort-bypassed: false
-      ort-version: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
+      ort-version: "87.3.0" # pin ORT: "latest" is unstable; >=87.2.0 required by current ort-config@main rules
       node-version: "24"
       runs-on: '["ubuntu-24.04"]'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       code-checks-bypassed: false
       ort-enabled: true
       ort-bypassed: false
-      ort-version: "latest"
+      ort-version: "85.0.0" # HACK: pin ORT version due to java.util.NoSuchElementException in 85.1.0
       node-version: "24"
       runs-on: '["ubuntu-24.04"]'
 


### PR DESCRIPTION
### Applicable issues

- N/A

### Description of changes

The PR and Release workflows pull the ORT scanner via `ort-version: "latest"`, which now resolves to ORT `85.1.0` — a release that crashes with `java.util.NoSuchElementException` and fails CI. This pins ORT to the last known-good version `85.0.0` (matching the upstream `ai-dial-ci` hotfix).

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.