### PR TITLE
chore: correct loading text

### DIFF
--- a/src/constants/i18n-keys.ts
+++ b/src/constants/i18n-keys.ts
@@ -107,7 +107,6 @@ export enum AdvancedViewI18nKeys {
 }
 
 export enum MessageI18nKeys {
-  STREAMING = 'message.streaming',
   PROCESSING_REVIEW = 'message.processingReview',
   QUERY_UPDATED_MANUALLY = 'message.queryUpdatedManually',
   SET_TO = 'message.setTo',

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -88,11 +88,10 @@
     "fullLimitMessage": "Full dataset is available in data explorer"
   },
   "message": {
-    "streaming": "I'm on it! Please wait...",
     "processingReview": "View Processing Steps",
     "queryUpdatedManually": "Query has been updated manually.",
     "setTo": " set to ",
-    "loading": "I'm on it! Please wait..."
+    "loading": "Connecting to the Global Trusted Data Commons..."
   },
   "conversation": {
     "delete": "Delete",


### PR DESCRIPTION

### Description of changes

 Updated the conversation loading message from the generic "I'm on it! Please wait..." to "Connecting to the Global Trusted Data Commons..." and removed the unused streaming i18n key (both the MessageI18nKeys.STREAMING enum  entry and the message.streaming locale string).
