### PR TITLE
feat: replace fixed modal body env vars with single markdown content field

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -17,6 +17,12 @@ NEXTAUTH_URL=http://localhost:4200
 LOG_LEVEL=debug # Options: trace, debug, info, warn, error, fatal
 NEXT_PUBLIC_DEBUG=true # Enable verbose client-side logging
 
+# Info Banner (optional warning strip shown above chat)
+# INFO_BANNER_MESSAGE="We are currently in User Acceptance Testing."
+# INFO_BANNER_LINK_TEXT="Click here."
+# INFO_BANNER_MODAL_TITLE="More details"
+# INFO_BANNER_MODAL_CONTENT="Body text supporting **markdown**.\n\n## Section\n\nParagraph."
+
 # CSP
 # ALLOWED_FRAME_ANCESTORS=""
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ The table below lists environment variables that control configurable content di
 | `INFO_BANNER_MESSAGE`         | No | Plain text message displayed in the informational banner below the footer (e.g., maintenance notice or system alert). If not set, the banner is hidden. | Any string | |
 | `INFO_BANNER_LINK_TEXT`       | No | Label for the clickable link appended to the banner message. When set, clicking the link opens a modal. If not set, no link is shown. Requires `INFO_BANNER_MESSAGE`. | Any string | |
 | `INFO_BANNER_MODAL_TITLE`     | No | Heading of the modal dialog opened by the banner link. Requires `INFO_BANNER_MESSAGE` and `INFO_BANNER_LINK_TEXT`. | Any string | |
-| `INFO_BANNER_MODAL_CONTENT`   | No | Body of the modal dialog, rendered as Markdown. Supports headings (`##`, `###`), paragraphs, bold/italic, and lists. Multi-line values are supported using backtick quoting in `.env` files. Requires `INFO_BANNER_MESSAGE` and `INFO_BANNER_LINK_TEXT`. | Markdown string | |
+| `INFO_BANNER_MODAL_CONTENT`   | No | Body of the modal dialog, rendered as Markdown. Supports headings (`##`, `###`), paragraphs, bold/italic, and lists. Requires `INFO_BANNER_MESSAGE` and `INFO_BANNER_LINK_TEXT`. | Markdown string | |
 | `CONTENT_MANAGEMENT_POLICY_URL` | No | URL of the page describing the content management policy. Displayed in a warning message when a user's prompt triggers the content filtering policy. | URL |
 
 

--- a/README.md
+++ b/README.md
@@ -254,11 +254,7 @@ The table below lists environment variables that control configurable content di
 | `INFO_BANNER_MESSAGE`         | No | Plain text message displayed in the informational banner below the footer (e.g., maintenance notice or system alert). If not set, the banner is hidden. | Any string | |
 | `INFO_BANNER_LINK_TEXT`       | No | Label for the clickable link appended to the banner message. When set, clicking the link opens a modal. If not set, no link is shown. Requires `INFO_BANNER_MESSAGE`. | Any string | |
 | `INFO_BANNER_MODAL_TITLE`     | No | Heading of the modal dialog opened by the banner link. Requires `INFO_BANNER_MESSAGE` and `INFO_BANNER_LINK_TEXT`. | Any string | |
-| `INFO_BANNER_MODAL_BODY`      | No | Introductory paragraph displayed at the top of the modal body. Requires `INFO_BANNER_MESSAGE` and `INFO_BANNER_LINK_TEXT`. | Any string | |
-| `INFO_BANNER_MODAL_SECTION_TITLE` | No | Sub-heading displayed above the modal paragraphs (e.g. "Disclaimer"). Requires `INFO_BANNER_MESSAGE` and `INFO_BANNER_LINK_TEXT`. | Any string | |
-| `INFO_BANNER_MODAL_P1`        | No | First paragraph in the modal body section. Requires `INFO_BANNER_MESSAGE` and `INFO_BANNER_LINK_TEXT`. | Any string | |
-| `INFO_BANNER_MODAL_P2`        | No | Second paragraph in the modal body section. Requires `INFO_BANNER_MESSAGE` and `INFO_BANNER_LINK_TEXT`. | Any string | |
-| `INFO_BANNER_MODAL_P3`        | No | Third paragraph in the modal body section. Requires `INFO_BANNER_MESSAGE` and `INFO_BANNER_LINK_TEXT`. | Any string | |
+| `INFO_BANNER_MODAL_CONTENT`   | No | Body of the modal dialog, rendered as Markdown. Supports headings (`##`, `###`), paragraphs, bold/italic, and lists. Multi-line values are supported using backtick quoting in `.env` files. Requires `INFO_BANNER_MESSAGE` and `INFO_BANNER_LINK_TEXT`. | Markdown string | |
 | `CONTENT_MANAGEMENT_POLICY_URL` | No | URL of the page describing the content management policy. Displayed in a warning message when a user's prompt triggers the content filtering policy. | URL |
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^19.2.1",
         "react-flatpickr": "^4.0.11",
+        "react-markdown": "^10.1.0",
         "react-virtualized-auto-sizer": "^1.0.26",
         "react-window": "^1.8.11",
         "remark-gfm": "^4.0.1",
@@ -10563,6 +10564,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
       "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^19.2.1",
     "react-flatpickr": "^4.0.11",
+    "react-markdown": "^10.1.0",
     "react-virtualized-auto-sizer": "^1.0.26",
     "react-window": "^1.8.11",
     "remark-gfm": "^4.0.1",

--- a/src/components/Footer/DisclaimerModal.tsx
+++ b/src/components/Footer/DisclaimerModal.tsx
@@ -31,7 +31,7 @@ export const DisclaimerModal = ({
           className="body-1 flex flex-col gap-2 overflow-y-auto p-6"
         >
           {modalContent && (
-            <div className="[&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5">
+            <div className="space-y-3 [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5">
               <ReactMarkdown remarkPlugins={[remarkGfm]}>
                 {modalContent}
               </ReactMarkdown>

--- a/src/components/Footer/DisclaimerModal.tsx
+++ b/src/components/Footer/DisclaimerModal.tsx
@@ -1,28 +1,17 @@
 'use client';
 
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { Popup, PopUpState } from '@epam/statgpt-ui-components';
 
 interface Props {
   isOpen: boolean;
   onClose: () => void;
   title?: string;
-  body?: string;
-  sectionTitle?: string;
-  p1?: string;
-  p2?: string;
-  p3?: string;
+  modalContent?: string;
 }
 
-export const DisclaimerModal = ({
-  isOpen,
-  onClose,
-  title,
-  body,
-  sectionTitle,
-  p1,
-  p2,
-  p3,
-}: Props) => {
+export const DisclaimerModal = ({ isOpen, onClose, title, modalContent }: Props) => {
   return (
     <Popup
       portalId="disclaimer-modal"
@@ -36,11 +25,11 @@ export const DisclaimerModal = ({
           key="body"
           className="body-1 flex flex-col gap-2 overflow-y-auto p-6"
         >
-          {body && <p>{body}</p>}
-          {sectionTitle && <p className="h2 mt-3">{sectionTitle}</p>}
-          {p1 && <p>{p1}</p>}
-          {p2 && <p>{p2}</p>}
-          {p3 && <p>{p3}</p>}
+          {modalContent && (
+            <div className="[&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>{modalContent}</ReactMarkdown>
+            </div>
+          )}
         </div>,
       ]}
     </Popup>

--- a/src/components/Footer/DisclaimerModal.tsx
+++ b/src/components/Footer/DisclaimerModal.tsx
@@ -11,7 +11,12 @@ interface Props {
   modalContent?: string;
 }
 
-export const DisclaimerModal = ({ isOpen, onClose, title, modalContent }: Props) => {
+export const DisclaimerModal = ({
+  isOpen,
+  onClose,
+  title,
+  modalContent,
+}: Props) => {
   return (
     <Popup
       portalId="disclaimer-modal"
@@ -27,7 +32,9 @@ export const DisclaimerModal = ({ isOpen, onClose, title, modalContent }: Props)
         >
           {modalContent && (
             <div className="[&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{modalContent}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {modalContent}
+              </ReactMarkdown>
             </div>
           )}
         </div>,

--- a/src/components/Footer/WarnBanner.tsx
+++ b/src/components/Footer/WarnBanner.tsx
@@ -8,11 +8,7 @@ export const WarnBanner = ({
   message,
   linkText,
   modalTitle,
-  modalBody,
-  modalSectionTitle,
-  modalP1,
-  modalP2,
-  modalP3,
+  modalContent,
 }: BannerConfig) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -36,11 +32,7 @@ export const WarnBanner = ({
           isOpen={isOpen}
           onClose={() => setIsOpen(false)}
           title={modalTitle}
-          body={modalBody}
-          sectionTitle={modalSectionTitle}
-          p1={modalP1}
-          p2={modalP2}
-          p3={modalP3}
+          modalContent={modalContent}
         />
       )}
     </>

--- a/src/components/Footer/__tests__/DisclaimerModal.spec.tsx
+++ b/src/components/Footer/__tests__/DisclaimerModal.spec.tsx
@@ -30,7 +30,9 @@ describe('DisclaimerModal', () => {
         modalContent={'## Disclaimer\n\nSome paragraph.'}
       />,
     );
-    expect(screen.getByRole('heading', { level: 2, name: 'Disclaimer' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Disclaimer' }),
+    ).toBeInTheDocument();
   });
 
   it('renders markdown paragraphs as p elements when open', () => {
@@ -45,9 +47,7 @@ describe('DisclaimerModal', () => {
   });
 
   it('renders nothing inside popup when modalContent is undefined', () => {
-    render(
-      <DisclaimerModal isOpen={true} onClose={() => {}} />,
-    );
+    render(<DisclaimerModal isOpen={true} onClose={() => {}} />);
     expect(screen.getByTestId('popup')).toBeInTheDocument();
     expect(screen.queryByRole('heading')).toBeNull();
   });

--- a/src/components/Footer/__tests__/DisclaimerModal.spec.tsx
+++ b/src/components/Footer/__tests__/DisclaimerModal.spec.tsx
@@ -51,4 +51,16 @@ describe('DisclaimerModal', () => {
     expect(screen.getByTestId('popup')).toBeInTheDocument();
     expect(screen.queryByRole('heading')).toBeNull();
   });
+
+  it('renders markdown list items as a ul element when open', () => {
+    render(
+      <DisclaimerModal
+        isOpen={true}
+        onClose={() => {}}
+        modalContent={'- Item one\n- Item two'}
+      />,
+    );
+    expect(screen.getByRole('list')).toBeInTheDocument();
+    expect(screen.getByText('Item one')).toBeInTheDocument();
+  });
 });

--- a/src/components/Footer/__tests__/DisclaimerModal.spec.tsx
+++ b/src/components/Footer/__tests__/DisclaimerModal.spec.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { DisclaimerModal } from '../DisclaimerModal';
+
+vi.mock('@epam/statgpt-ui-components', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Popup: ({ children, state }: { children: any; state: string }) =>
+    state === 'opened' ? <div data-testid="popup">{children}</div> : null,
+  PopUpState: { Opened: 'opened', Closed: 'closed' },
+}));
+
+describe('DisclaimerModal', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <DisclaimerModal
+        isOpen={false}
+        onClose={() => {}}
+        modalContent={'## Title\n\nSome text.'}
+      />,
+    );
+    expect(screen.queryByTestId('popup')).toBeNull();
+  });
+
+  it('renders markdown headings as h2 elements when open', () => {
+    render(
+      <DisclaimerModal
+        isOpen={true}
+        onClose={() => {}}
+        modalContent={'## Disclaimer\n\nSome paragraph.'}
+      />,
+    );
+    expect(screen.getByRole('heading', { level: 2, name: 'Disclaimer' })).toBeInTheDocument();
+  });
+
+  it('renders markdown paragraphs as p elements when open', () => {
+    render(
+      <DisclaimerModal
+        isOpen={true}
+        onClose={() => {}}
+        modalContent="Some paragraph text."
+      />,
+    );
+    expect(screen.getByText('Some paragraph text.')).toBeInTheDocument();
+  });
+
+  it('renders nothing inside popup when modalContent is undefined', () => {
+    render(
+      <DisclaimerModal isOpen={true} onClose={() => {}} />,
+    );
+    expect(screen.getByTestId('popup')).toBeInTheDocument();
+    expect(screen.queryByRole('heading')).toBeNull();
+  });
+});

--- a/src/types/banner-config.ts
+++ b/src/types/banner-config.ts
@@ -2,9 +2,5 @@ export interface BannerConfig {
   message: string;
   linkText?: string;
   modalTitle?: string;
-  modalBody?: string;
-  modalSectionTitle?: string;
-  modalP1?: string;
-  modalP2?: string;
-  modalP3?: string;
+  modalContent?: string;
 }

--- a/src/utils/__tests__/banner.spec.ts
+++ b/src/utils/__tests__/banner.spec.ts
@@ -1,0 +1,46 @@
+import { getBannerConfig } from '../banner';
+
+describe('getBannerConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns undefined when INFO_BANNER_MESSAGE is not set', () => {
+    delete process.env.INFO_BANNER_MESSAGE;
+    expect(getBannerConfig()).toBeUndefined();
+  });
+
+  it('returns config with message only when no optional vars are set', () => {
+    process.env.INFO_BANNER_MESSAGE = 'Test banner';
+    delete process.env.INFO_BANNER_LINK_TEXT;
+    delete process.env.INFO_BANNER_MODAL_TITLE;
+    delete process.env.INFO_BANNER_MODAL_CONTENT;
+
+    expect(getBannerConfig()).toEqual({
+      message: 'Test banner',
+      linkText: undefined,
+      modalTitle: undefined,
+      modalContent: undefined,
+    });
+  });
+
+  it('maps all env vars to config fields', () => {
+    process.env.INFO_BANNER_MESSAGE = 'Banner text';
+    process.env.INFO_BANNER_LINK_TEXT = 'Click here';
+    process.env.INFO_BANNER_MODAL_TITLE = 'Modal title';
+    process.env.INFO_BANNER_MODAL_CONTENT = '## Heading\n\nParagraph text.';
+
+    expect(getBannerConfig()).toEqual({
+      message: 'Banner text',
+      linkText: 'Click here',
+      modalTitle: 'Modal title',
+      modalContent: '## Heading\n\nParagraph text.',
+    });
+  });
+});

--- a/src/utils/__tests__/banner.spec.ts
+++ b/src/utils/__tests__/banner.spec.ts
@@ -16,6 +16,11 @@ describe('getBannerConfig', () => {
     expect(getBannerConfig()).toBeUndefined();
   });
 
+  it('returns undefined when INFO_BANNER_MESSAGE is an empty string', () => {
+    process.env.INFO_BANNER_MESSAGE = '';
+    expect(getBannerConfig()).toBeUndefined();
+  });
+
   it('returns config with message only when no optional vars are set', () => {
     process.env.INFO_BANNER_MESSAGE = 'Test banner';
     delete process.env.INFO_BANNER_LINK_TEXT;

--- a/src/utils/banner.ts
+++ b/src/utils/banner.ts
@@ -8,10 +8,6 @@ export const getBannerConfig = (): BannerConfig | undefined => {
     message,
     linkText: process.env.INFO_BANNER_LINK_TEXT,
     modalTitle: process.env.INFO_BANNER_MODAL_TITLE,
-    modalBody: process.env.INFO_BANNER_MODAL_BODY,
-    modalSectionTitle: process.env.INFO_BANNER_MODAL_SECTION_TITLE,
-    modalP1: process.env.INFO_BANNER_MODAL_P1,
-    modalP2: process.env.INFO_BANNER_MODAL_P2,
-    modalP3: process.env.INFO_BANNER_MODAL_P3,
+    modalContent: process.env.INFO_BANNER_MODAL_CONTENT,
   };
 };


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- https://github.com/epam/statgpt-global-trusted-data-commons/issues/295

### Description of changes

- Replaces five fixed plain-text env vars (`INFO_BANNER_MODAL_BODY`, `INFO_BANNER_MODAL_SECTION_TITLE`, `INFO_BANNER_MODAL_P1`, `INFO_BANNER_MODAL_P2`, and `INFO_BANNER_MODAL_P3`) with a single `INFO_BANNER_MODAL_CONTENT` markdown env var.
- Renders modal content using `react-markdown` and `remark-gfm`, allowing operators to use headings, paragraphs, lists, tables, and other markdown elements without code changes.
- Applies heading and paragraph styles automatically through the existing global `fonts.scss` rules, with list indentation provided via Tailwind modifiers on the wrapper.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
