### PR TITLE
feat: replace WarnBanner plain text + linkText with markdown message supporting inline mailto and #popup links

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This project uses:
 
 ```bash
 npm install
-mpn run start
+npm run start
 ```
 
 ## 💻 Development
@@ -82,7 +82,7 @@ mpn run start
 1. **Clone the repository**
    ```bash
    git clone https://github.com/epam/statgpt-global-trusted-data-commons.git
-   cd statgpt-portal-frontend
+   cd statgpt-global-trusted-data-commons
    ```
 
 2. **Install Dependencies**
@@ -251,10 +251,9 @@ The table below lists environment variables that control configurable content di
 | Variable                          |                         Required                         | Description                                                                                                                                                                                                                                                      | Available Values                                                                                                                | Default values                                  |
 |-----------------------------------| :------------------------------------------------------: |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
 | `CLIENT_CONTACT_SUPPORT_URL`    |   No    | URL of the contact support page displayed to users within the application.                                                                                                                                                                                                                                                                                          | URL                                                                                       |  |
-| `INFO_BANNER_MESSAGE`         | No | Plain text message displayed in the informational banner below the footer (e.g., maintenance notice or system alert). If not set, the banner is hidden. | Any string | |
-| `INFO_BANNER_LINK_TEXT`       | No | Label for the clickable link appended to the banner message. When set, clicking the link opens a modal. If not set, no link is shown. Requires `INFO_BANNER_MESSAGE`. | Any string | |
-| `INFO_BANNER_MODAL_TITLE`     | No | Heading of the modal dialog opened by the banner link. Requires `INFO_BANNER_MESSAGE` and `INFO_BANNER_LINK_TEXT`. | Any string | |
-| `INFO_BANNER_MODAL_CONTENT`   | No | Body of the modal dialog, rendered as Markdown. Supports headings (`##`, `###`), paragraphs, bold/italic, and lists. Requires `INFO_BANNER_MESSAGE` and `INFO_BANNER_LINK_TEXT`. | Markdown string | |
+| `INFO_BANNER_MESSAGE`         | No | Markdown message displayed in the informational banner below the footer (e.g., maintenance notice or system alert). If not set, the banner is hidden. Supports inline links: `mailto:` links render as external anchors; a `[link text](#popup)` link opens the modal configured via `INFO_BANNER_MODAL_TITLE` / `INFO_BANNER_MODAL_CONTENT`. | Markdown string | |
+| `INFO_BANNER_MODAL_TITLE`     | No | Heading of the modal dialog. Requires `INFO_BANNER_MESSAGE` containing a `[text](#popup)` link. | Any string | |
+| `INFO_BANNER_MODAL_CONTENT`   | No | Body of the modal dialog, rendered as Markdown. Supports headings (`##`, `###`), paragraphs, bold/italic, lists, tables, and other GFM features. Requires `INFO_BANNER_MESSAGE` containing a `[text](#popup)` link. | Markdown string | |
 | `CONTENT_MANAGEMENT_POLICY_URL` | No | URL of the page describing the content management policy. Displayed in a warning message when a user's prompt triggers the content filtering policy. | URL |
 
 

--- a/src/components/Footer/WarnBanner.tsx
+++ b/src/components/Footer/WarnBanner.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
 import { BannerConfig } from '../../types/banner-config';
 import { DisclaimerModal } from './DisclaimerModal';
 
 export const WarnBanner = ({
   message,
-  linkText,
   modalTitle,
   modalContent,
 }: BannerConfig) => {
@@ -15,26 +15,42 @@ export const WarnBanner = ({
   return (
     <>
       <div className="h4 flex min-h-10 w-full items-center justify-center bg-semantic-warning-light px-2 py-1 text-center text-neutral-900">
-        <span>
-          {message}{' '}
-          {linkText && (
-            <button
-              className="cursor-pointer text-blue-600"
-              onClick={() => setIsOpen(true)}
-            >
-              {linkText}
-            </button>
-          )}
-        </span>
+        <ReactMarkdown
+          components={{
+            a: ({ href, children }) => {
+              if (href === '#popup') {
+                return (
+                  <button
+                    type="button"
+                    className="cursor-pointer text-blue-600"
+                    onClick={() => setIsOpen(true)}
+                  >
+                    {children}
+                  </button>
+                );
+              }
+              return (
+                <a
+                  href={href}
+                  className="text-blue-600"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {children}
+                </a>
+              );
+            },
+          }}
+        >
+          {message}
+        </ReactMarkdown>
       </div>
-      {linkText && (
-        <DisclaimerModal
-          isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
-          title={modalTitle}
-          modalContent={modalContent}
-        />
-      )}
+      <DisclaimerModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        title={modalTitle}
+        modalContent={modalContent}
+      />
     </>
   );
 };

--- a/src/components/Footer/__tests__/WarnBanner.spec.tsx
+++ b/src/components/Footer/__tests__/WarnBanner.spec.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { WarnBanner } from '../WarnBanner';
+
+vi.mock('@epam/statgpt-ui-components', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Popup: ({ children, state }: { children: any; state: string }) =>
+    state === 'opened' ? <div data-testid="popup">{children}</div> : null,
+  PopUpState: { Opened: 'opened', Closed: 'closed' },
+}));
+
+describe('WarnBanner', () => {
+  it('renders the plain message text', () => {
+    render(<WarnBanner message="System is under maintenance." />);
+    expect(
+      screen.getByText('System is under maintenance.'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a mailto link as an anchor element', () => {
+    render(
+      <WarnBanner message="Contact [support](mailto:support@example.com) for help." />,
+    );
+    const link = screen.getByRole('link', { name: 'support' });
+    expect(link).toHaveAttribute('href', 'mailto:support@example.com');
+    expect(link.tagName).toBe('A');
+  });
+
+  it('renders a #popup link as a button', () => {
+    render(
+      <WarnBanner
+        message="For details, [click here](#popup)."
+        modalTitle="Details"
+        modalContent="Some content."
+      />,
+    );
+    const button = screen.getByRole('button', { name: 'click here' });
+    expect(button).toBeInTheDocument();
+    expect(button.tagName).toBe('BUTTON');
+  });
+
+  it('opens the modal when the #popup button is clicked', () => {
+    render(
+      <WarnBanner
+        message="For details, [click here](#popup)."
+        modalTitle="Details"
+        modalContent="Some content."
+      />,
+    );
+    expect(screen.queryByTestId('popup')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'click here' }));
+    expect(screen.getByTestId('popup')).toBeInTheDocument();
+  });
+
+  it('opens an empty modal when #popup is clicked but no modal content is configured', () => {
+    render(<WarnBanner message="For details, [click here](#popup)." />);
+    fireEvent.click(screen.getByRole('button', { name: 'click here' }));
+    expect(screen.getByTestId('popup')).toBeInTheDocument();
+  });
+
+  it('renders both a mailto link and a #popup button in the same message', () => {
+    render(
+      <WarnBanner
+        message="Please [report issue](mailto:help@example.com). For more, [click here](#popup)."
+        modalTitle="More info"
+      />,
+    );
+    expect(screen.getByRole('link', { name: 'report issue' })).toHaveAttribute(
+      'href',
+      'mailto:help@example.com',
+    );
+    expect(
+      screen.getByRole('button', { name: 'click here' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/types/banner-config.ts
+++ b/src/types/banner-config.ts
@@ -1,6 +1,5 @@
 export interface BannerConfig {
   message: string;
-  linkText?: string;
   modalTitle?: string;
   modalContent?: string;
 }

--- a/src/utils/__tests__/banner.spec.ts
+++ b/src/utils/__tests__/banner.spec.ts
@@ -23,13 +23,11 @@ describe('getBannerConfig', () => {
 
   it('returns config with message only when no optional vars are set', () => {
     process.env.INFO_BANNER_MESSAGE = 'Test banner';
-    delete process.env.INFO_BANNER_LINK_TEXT;
     delete process.env.INFO_BANNER_MODAL_TITLE;
     delete process.env.INFO_BANNER_MODAL_CONTENT;
 
     expect(getBannerConfig()).toEqual({
       message: 'Test banner',
-      linkText: undefined,
       modalTitle: undefined,
       modalContent: undefined,
     });
@@ -37,13 +35,11 @@ describe('getBannerConfig', () => {
 
   it('maps all env vars to config fields', () => {
     process.env.INFO_BANNER_MESSAGE = 'Banner text';
-    process.env.INFO_BANNER_LINK_TEXT = 'Click here';
     process.env.INFO_BANNER_MODAL_TITLE = 'Modal title';
     process.env.INFO_BANNER_MODAL_CONTENT = '## Heading\n\nParagraph text.';
 
     expect(getBannerConfig()).toEqual({
       message: 'Banner text',
-      linkText: 'Click here',
       modalTitle: 'Modal title',
       modalContent: '## Heading\n\nParagraph text.',
     });

--- a/src/utils/banner.ts
+++ b/src/utils/banner.ts
@@ -6,7 +6,6 @@ export const getBannerConfig = (): BannerConfig | undefined => {
 
   return {
     message,
-    linkText: process.env.INFO_BANNER_LINK_TEXT,
     modalTitle: process.env.INFO_BANNER_MODAL_TITLE,
     modalContent: process.env.INFO_BANNER_MODAL_CONTENT,
   };


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- https://github.com/epam/statgpt-global-trusted-data-commons/issues/303

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
