### PR TITLE
fix: show "Last updated" date in the Dataset info panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,12 @@
         "@epam/ai-dial-chat-visualizer-connector": "^0.32.0",
         "@epam/ai-dial-shared": "^0.43.3",
         "@epam/ai-dial-visualizer-connector": "^0.32.0",
-        "@epam/statgpt-conversation-list": "0.7.0-dev.18",
-        "@epam/statgpt-conversation-view": "0.7.0-dev.18",
-        "@epam/statgpt-dial-toolkit": "0.7.0-dev.18",
-        "@epam/statgpt-sdmx-toolkit": "0.7.0-dev.18",
-        "@epam/statgpt-shared-toolkit": "0.7.0-dev.18",
-        "@epam/statgpt-ui-components": "0.7.0-dev.18",
+        "@epam/statgpt-conversation-list": "0.7.0-dev.20",
+        "@epam/statgpt-conversation-view": "0.7.0-dev.20",
+        "@epam/statgpt-dial-toolkit": "0.7.0-dev.20",
+        "@epam/statgpt-sdmx-toolkit": "0.7.0-dev.20",
+        "@epam/statgpt-shared-toolkit": "0.7.0-dev.20",
+        "@epam/statgpt-ui-components": "0.7.0-dev.20",
         "@floating-ui/react": "^0.27.16",
         "@monaco-editor/react": "^4.7.0",
         "@tabler/icons-react": "^3.34.0",
@@ -1961,14 +1961,14 @@
       "integrity": "sha512-Pk/77X9m6c7yq4ACt/voC7jobKuRHPW8yeuxZvY3FeemBOxy85y9fph/Ak5uwZmAPQJURCBGgIQ9Yyb8y3M5+Q=="
     },
     "node_modules/@epam/statgpt-conversation-list": {
-      "version": "0.7.0-dev.18",
-      "resolved": "https://registry.npmjs.org/@epam/statgpt-conversation-list/-/statgpt-conversation-list-0.7.0-dev.18.tgz",
-      "integrity": "sha512-o7lXkXO/vR3t6UHhFNUj4kY6y+lZ2ScKFvu2N1Guj2v+xiOtq2HLV0zuFWcDS0ZH+0UEtvthXMvF5TpchugZMw==",
+      "version": "0.7.0-dev.20",
+      "resolved": "https://registry.npmjs.org/@epam/statgpt-conversation-list/-/statgpt-conversation-list-0.7.0-dev.20.tgz",
+      "integrity": "sha512-g8PcJMhbqrNK13EBEp6L8/ZScdHlrXnnPwMvQvr7dgWYDEVwgLd5VQuL2Sm9wUgumucrZ46duJce+q6T1yhxYQ==",
       "license": "MIT",
       "dependencies": {
-        "@epam/statgpt-dial-toolkit": "0.7.0-dev.18",
-        "@epam/statgpt-shared-toolkit": "0.7.0-dev.18",
-        "@epam/statgpt-ui-components": "0.7.0-dev.18"
+        "@epam/statgpt-dial-toolkit": "0.7.0-dev.20",
+        "@epam/statgpt-shared-toolkit": "0.7.0-dev.20",
+        "@epam/statgpt-ui-components": "0.7.0-dev.20"
       },
       "peerDependencies": {
         "@epam/ai-dial-shared": "^0.43.3",
@@ -1980,16 +1980,16 @@
       }
     },
     "node_modules/@epam/statgpt-conversation-view": {
-      "version": "0.7.0-dev.18",
-      "resolved": "https://registry.npmjs.org/@epam/statgpt-conversation-view/-/statgpt-conversation-view-0.7.0-dev.18.tgz",
-      "integrity": "sha512-H1R7T+T96wZiQqSxBdoXjv8jJgtxm6hBgZ4LAKGC/kngJzNRNpyc4YVo/kOk0NK49XHhGLE+qAS8v5/mM9mFbA==",
+      "version": "0.7.0-dev.20",
+      "resolved": "https://registry.npmjs.org/@epam/statgpt-conversation-view/-/statgpt-conversation-view-0.7.0-dev.20.tgz",
+      "integrity": "sha512-6j3dK8cFxksYNqY1WSjy9oL1OKY06xiZaW2XhH78/d2CGqJcfZ4CTOPchcbTKEjSUvnv6BKBCnP8gmREDbbJ/w==",
       "license": "MIT",
       "dependencies": {
-        "@epam/statgpt-conversation-list": "0.7.0-dev.18",
-        "@epam/statgpt-dial-toolkit": "0.7.0-dev.18",
-        "@epam/statgpt-sdmx-toolkit": "0.7.0-dev.18",
-        "@epam/statgpt-shared-toolkit": "0.7.0-dev.18",
-        "@epam/statgpt-ui-components": "0.7.0-dev.18"
+        "@epam/statgpt-conversation-list": "0.7.0-dev.20",
+        "@epam/statgpt-dial-toolkit": "0.7.0-dev.20",
+        "@epam/statgpt-sdmx-toolkit": "0.7.0-dev.20",
+        "@epam/statgpt-shared-toolkit": "0.7.0-dev.20",
+        "@epam/statgpt-ui-components": "0.7.0-dev.20"
       },
       "peerDependencies": {
         "@epam/ai-dial-shared": "^0.43.3",
@@ -2014,25 +2014,25 @@
       }
     },
     "node_modules/@epam/statgpt-dial-toolkit": {
-      "version": "0.7.0-dev.18",
-      "resolved": "https://registry.npmjs.org/@epam/statgpt-dial-toolkit/-/statgpt-dial-toolkit-0.7.0-dev.18.tgz",
-      "integrity": "sha512-Kw2gcvF097iBV2DlXHwv4D1c4fLxQaF/4NQkHcd4xLK8phYOD4tD8uyz7hlRra4GRXTszAMyBdjqWOE0DsWwqQ==",
+      "version": "0.7.0-dev.20",
+      "resolved": "https://registry.npmjs.org/@epam/statgpt-dial-toolkit/-/statgpt-dial-toolkit-0.7.0-dev.20.tgz",
+      "integrity": "sha512-3LfbPr9ct6LgvQaPNNYCQYX8hzOASXu6f9lDf3xCi9wBLryi0YH2e/+YK5313g39aa9/XwiMDbKc0mgKHCUt+A==",
       "license": "MIT",
       "dependencies": {
-        "@epam/statgpt-shared-toolkit": "0.7.0-dev.18"
+        "@epam/statgpt-shared-toolkit": "0.7.0-dev.20"
       },
       "peerDependencies": {
         "@epam/ai-dial-shared": "^0.43.3"
       }
     },
     "node_modules/@epam/statgpt-sdmx-toolkit": {
-      "version": "0.7.0-dev.18",
-      "resolved": "https://registry.npmjs.org/@epam/statgpt-sdmx-toolkit/-/statgpt-sdmx-toolkit-0.7.0-dev.18.tgz",
-      "integrity": "sha512-IS6EH2RAibjTknOCFo5NqWjVcZZDNq2nZ8WerEgct3H6cmWVgfHEJg6vcjB4H2wavQy2sgS3iw2X4OEh6N1VSw==",
+      "version": "0.7.0-dev.20",
+      "resolved": "https://registry.npmjs.org/@epam/statgpt-sdmx-toolkit/-/statgpt-sdmx-toolkit-0.7.0-dev.20.tgz",
+      "integrity": "sha512-LofAH1bxbMFxQOoHkAEPBwDHFty2CGOkw7xI0Gap7i+ky0/nnZPGO3J4Gw4lenFJ19UTqzjEmnPYaSeA1DAFZQ==",
       "license": "MIT",
       "dependencies": {
-        "@epam/statgpt-dial-toolkit": "0.7.0-dev.18",
-        "@epam/statgpt-shared-toolkit": "0.7.0-dev.18"
+        "@epam/statgpt-dial-toolkit": "0.7.0-dev.20",
+        "@epam/statgpt-shared-toolkit": "0.7.0-dev.20"
       },
       "peerDependencies": {
         "compare-versions": "^6.1.1",
@@ -2040,9 +2040,9 @@
       }
     },
     "node_modules/@epam/statgpt-shared-toolkit": {
-      "version": "0.7.0-dev.18",
-      "resolved": "https://registry.npmjs.org/@epam/statgpt-shared-toolkit/-/statgpt-shared-toolkit-0.7.0-dev.18.tgz",
-      "integrity": "sha512-mPO9c7qn0ni8cD68KdgC/WhIpNlmOZE3xmWT0ijCr46iW7EEEzrhvEVgQGLBkQteu6b1k6jAJZO9MaNAZgszXg==",
+      "version": "0.7.0-dev.20",
+      "resolved": "https://registry.npmjs.org/@epam/statgpt-shared-toolkit/-/statgpt-shared-toolkit-0.7.0-dev.20.tgz",
+      "integrity": "sha512-bbOA4HbyFXyeHJrH/TrsY7MH0OhH1Gby2oKAVdd1Cqj+TdcEYJqj7rT1k1uR/xQlHydXmAd2jfRCohPm+1f30A==",
       "license": "MIT",
       "peerDependencies": {
         "@epam/ai-dial-shared": "^0.43.3",
@@ -2050,12 +2050,12 @@
       }
     },
     "node_modules/@epam/statgpt-ui-components": {
-      "version": "0.7.0-dev.18",
-      "resolved": "https://registry.npmjs.org/@epam/statgpt-ui-components/-/statgpt-ui-components-0.7.0-dev.18.tgz",
-      "integrity": "sha512-mEP4IuTHCzem8SAwaftPqZG2FhwHfbDgr+fu7YVhCHy0T5tWx/FHI4oyvEHawePYQR+Yfv6AbT9g0ZkxhydDZw==",
+      "version": "0.7.0-dev.20",
+      "resolved": "https://registry.npmjs.org/@epam/statgpt-ui-components/-/statgpt-ui-components-0.7.0-dev.20.tgz",
+      "integrity": "sha512-3aHfNZ4u7gu3gEOemGEUYacc/JdeTigYObjPjMMv1ZY1kHP0j99+8bZ6dEVCF7xTd0eQ1o+CpeX1+/IuKKHWog==",
       "license": "MIT",
       "dependencies": {
-        "@epam/statgpt-shared-toolkit": "0.7.0-dev.18"
+        "@epam/statgpt-shared-toolkit": "0.7.0-dev.20"
       },
       "peerDependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -9494,33 +9494,6 @@
         "client-only": "^0.0.1",
         "international-types": "^0.8.1",
         "server-only": "^0.0.1"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/no-case": {

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     "@epam/ai-dial-chat-visualizer-connector": "^0.32.0",
     "@epam/ai-dial-shared": "^0.43.3",
     "@epam/ai-dial-visualizer-connector": "^0.32.0",
-    "@epam/statgpt-conversation-list": "0.7.0-dev.18",
-    "@epam/statgpt-conversation-view": "0.7.0-dev.18",
-    "@epam/statgpt-dial-toolkit": "0.7.0-dev.18",
-    "@epam/statgpt-sdmx-toolkit": "0.7.0-dev.18",
-    "@epam/statgpt-shared-toolkit": "0.7.0-dev.18",
-    "@epam/statgpt-ui-components": "0.7.0-dev.18",
+    "@epam/statgpt-conversation-list": "0.7.0-dev.20",
+    "@epam/statgpt-conversation-view": "0.7.0-dev.20",
+    "@epam/statgpt-dial-toolkit": "0.7.0-dev.20",
+    "@epam/statgpt-sdmx-toolkit": "0.7.0-dev.20",
+    "@epam/statgpt-shared-toolkit": "0.7.0-dev.20",
+    "@epam/statgpt-ui-components": "0.7.0-dev.20",
     "@floating-ui/react": "^0.27.16",
     "@monaco-editor/react": "^4.7.0",
     "@tabler/icons-react": "^3.34.0",
@@ -80,6 +80,7 @@
   },
   "overrides": {
     "minimatch": "10.2.3",
-    "picomatch": "4.0.4"
+    "picomatch": "4.0.4",
+    "postcss": "8.5.12"
   }
 }

--- a/src/app/[locale]/conversations/layout.tsx
+++ b/src/app/[locale]/conversations/layout.tsx
@@ -15,7 +15,10 @@ import { ClientProvidersWrapper } from '../../../components/ClientProvidersWrapp
 import { NoAccessView } from '../../../components/NoAccessView';
 import { ComponentsConfig } from '../../../components/configs/ComponentsConfig/ComponentsConfig';
 import { TextsConfig } from '../../../components/configs/TextsConfig/TextsConfig';
-import { buildDatasetDimensionsMetadataMap } from '@epam/statgpt-sdmx-toolkit';
+import {
+  buildDatasetDimensionsMetadataMap,
+  buildDatasetLastUpdatedMap,
+} from '@epam/statgpt-sdmx-toolkit';
 import { getDatasetsMetadata } from '../../actions/datasets-metadata';
 
 export default async function ConversationLayout({
@@ -67,6 +70,9 @@ export default async function ConversationLayout({
   const datasetDimensionsMetadataMap = metadata.data
     ? buildDatasetDimensionsMetadataMap(metadata.data)
     : {};
+  const datasetLastUpdatedMap = metadata.data
+    ? buildDatasetLastUpdatedMap(metadata.data)
+    : {};
 
   const contentManagementPolicyUrl = process.env.CONTENT_MANAGEMENT_POLICY_URL;
   const isCrossDatasetModeOn = parseBoolean(process.env.CROSS_DATASET_MODE);
@@ -82,6 +88,7 @@ export default async function ConversationLayout({
         <DeploymentConfigProvider config={configuration.data}>
           <ClientProvidersWrapper
             datasetDimensionsMetadataMap={datasetDimensionsMetadataMap}
+            datasetLastUpdatedMap={datasetLastUpdatedMap}
             isAgentAvailable={configuration.success}
             isCrossDatasetModeOn={isCrossDatasetModeOn}
             isMetadataInSidePanel={isMetadataInSidePanel}

--- a/src/components/ClientProvidersWrapper/ClientProvidersWrapper.tsx
+++ b/src/components/ClientProvidersWrapper/ClientProvidersWrapper.tsx
@@ -10,7 +10,10 @@ import {
   OnboardingProvider,
 } from '@epam/statgpt-conversation-view';
 import { AgentAvailabilityProvider } from '@epam/statgpt-ui-components';
-import { DatasetDimensionsMetadataMap } from '@epam/statgpt-sdmx-toolkit';
+import {
+  DatasetDimensionsMetadataMap,
+  DatasetLastUpdatedMap,
+} from '@epam/statgpt-sdmx-toolkit';
 
 export const ClientProvidersWrapper = ({
   children,
@@ -19,6 +22,7 @@ export const ClientProvidersWrapper = ({
   isMetadataInSidePanel,
   isTableSettingsFeatureEnabled,
   datasetDimensionsMetadataMap,
+  datasetLastUpdatedMap,
 }: {
   children: React.ReactNode;
   isAgentAvailable: boolean;
@@ -26,6 +30,7 @@ export const ClientProvidersWrapper = ({
   isMetadataInSidePanel: boolean;
   isTableSettingsFeatureEnabled: boolean;
   datasetDimensionsMetadataMap: DatasetDimensionsMetadataMap;
+  datasetLastUpdatedMap: DatasetLastUpdatedMap;
 }) => {
   return (
     <ConversationViewFeatureTogglesProvider
@@ -36,6 +41,7 @@ export const ClientProvidersWrapper = ({
       <AgentAvailabilityProvider isAgentAvailable={isAgentAvailable}>
         <DatasetDimensionsMetadataMapProvider
           map={datasetDimensionsMetadataMap}
+          lastUpdatedMap={datasetLastUpdatedMap}
         >
           <OnboardingProvider>
             <AdvancedViewProvider>


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/321

### Description of changes

**Surface last_updated_at from the datasets-metadata endpoint**

- Added `last_updated_at?: string | null` to `ChannelDataset` model.
- Added `DatasetLastUpdatedMap` type and `buildDatasetLastUpdatedMap` utility that builds a ShortUrn → timestamp map from the endpoint response.
- Extended `DatasetDimensionsMetadataMapProvider` with an optional `lastUpdatedMap` prop and a `getDatasetLastUpdated(dataflow)` getter on the context — deployment metadata is the primary source, SDMX annotation is the fallback.
- All five display sites (`DatasetInfo, MetadataCellRenderer, DatasetDetailCellRenderer, MergedDimensionCellRenderer, ObservationValueCellWithMetadata`) now call `getDatasetLastUpdated` from the context instead of `getLastUpdatedTime` directly.

### Checklist

- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
