### PR TITLE
fix: prevent mobile viewport scroll bounce and full-width advanced view panel

### DIFF
--- a/src/components/ConversationView/ConversationViewWrapper.tsx
+++ b/src/components/ConversationView/ConversationViewWrapper.tsx
@@ -522,7 +522,7 @@ const ConversationViewWrapper: FC<Props> = ({
         className={classNames(
           'flex flex-col h-full',
           isOpenedAdvancedView
-            ? 'w-[422px] border border-neutrals-400'
+            ? 'w-full sm-min:w-[422px] border border-neutrals-400'
             : 'w-full',
           isOpenedAdvancedView && isChatCollapsed && 'hidden',
         )}

--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -29,6 +29,13 @@ body {
   font-family: var(--font-open-sans), Arial, sans-serif;
 }
 
+html,
+body {
+  height: 100%; // fallback for browsers without dvh support
+  height: 100dvh; // tracks the real mobile viewport as the address bar shows/hides
+  overscroll-behavior: none;
+}
+
 .main-layout {
   background-image: url('/images/chat/layout.svg');
   background-size: cover;


### PR DESCRIPTION
### Applicable issues

- https://github.com/epam/statgpt-global-trusted-data-commons/issues/329

### Description of changes

- Fix advanced view chat panel taking a fixed 422px width on small viewports; now full-width below the `sm-min` breakpoint.
- Stop the mobile browser scroll-bounce that revealed content outside the viewport, by adding `overscroll-behavior: none` and switching to dynamic viewport height (`100dvh`, with a `100%` fallback) on `html`/`body`.

### Checklist

- [x] Title of the pull request follows Conventional Commits specification

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.